### PR TITLE
Tidy the inflammation dataset

### DIFF
--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -63,7 +63,7 @@ meaning that we:
 ```{r inflammation-gather}
 dat_long <- tidyr::gather(dat_labelled,
                          key = "day",
-                         value = "inflammation_score",
+                         value = "inflammatory_response",
                          V1:V40)
 tail(dat_long)
 ```
@@ -84,7 +84,7 @@ str(dat_long)
 The structure of our inflammation dataset is now a lot tidier than before and we
 can finally package it up in an R-supported format. Rename the dataframe to some-
 thing more self-descriptive than `dat...`, using for example
-`inflammation_scores <- dat_long` and then run `use_data(inflammation_scores)`.
+`inflammation <- dat_long` and then run `use_data(inflammation)`.
 
 ## Documenting datasets
 
@@ -101,11 +101,11 @@ same as the those for function documentation.
 > 1. How could the documentation file look in the end?
 >
 > > ## Solutions
-> > 1. `R/inflammation_scores.R`
-> > 1. `patient_ID`, `day` & `inflammation_score`
+> > 1. `R/inflammation.R`
+> > 1. `patient_ID`, `day` & `inflammatory_response`
 > > 1. See below:
 > > 
-> > #' Inflammation Scores Of Patients During Study...
+> > #' Inflammation In Patients During Study...
 > > #'
 > > #' @source Inflammation scores in patients that... This study was pre-registered at
 > > #'   \url{http://wwww.alltrials.net/study...}.
@@ -113,9 +113,9 @@ same as the those for function documentation.
 > > #' \describe{
 > > #'  \item{patient_ID}{A factor prepresenting the different patients}
 > > #'  \item{day}{Day of the inflammation measurement}
-> > #'  \item{inflammation_score}{Measured as described in the methods section of ...}
+> > #'  \item{inflammatory_response}{Measured as described in the methods section of ...}
 > > #' }
-> > #' "inflammation_scores"
+> > #' "inflammation"
 > {: .solution}
 {: .challenge}
 

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -23,12 +23,19 @@ knitr_fig_path("06-tidy-data-R-")
 
 In the preparations episode, we read in, visualised, centered and rescaled a
 dataset about inflammation in 60 patients measured over 40 days. Let's pretend
-we need to tidy it up for further analysis and publication.
+we need to tidy it up for further publication alongside the package we have been
+constructing.
+
+First, run `library(usethis)` and `use_data_raw()` and note the `Next:` instructions
+in the console. In particular, copy the `inflammation-*.csv` files to `data-raw`
+and start a `tidy-inflammation.R` file there to which you add the necessary lines
+of the following code examples. Think about which of them are purely for interactive
+checks of the tidying process. You needn't save those to "data creation scripts".
 
 ```{r inflammation-wide}
-dat <- read.csv(file = "data/inflammation-01.csv", header = FALSE)
 colnames(dat)
 rownames(dat)
+dat <- read.csv(file = "inflammation-01.csv", header = FALSE)
 ```
 
 You probably noticed that neither "patients" nor "days" is listed anywhere. Thus,

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -103,7 +103,7 @@ Please read through [r-pkgs.had.co.nz/data.html#documenting-data](http://r-pkgs.
 and keep in mind, that the descriptive tags for datasets are not entirely the
 same as the those for function documentation.
 
-> ## Challange: Document the dataset!
+> ## Challenge: Document the dataset!
 >
 > 1. Which file should we create to document our dataset?
 > 1. Which items of our dataset should be documented?
@@ -134,10 +134,10 @@ same as the those for function documentation.
 
 [MD]: https://rmarkdown.rstudio.com/authoring_basics.html
 
-After saving the raw data, the data creation script, the tidy dataset,and
+After saving the raw data, the data creation script, the tidy dataset, and
 the documentation file, what is left to do in our little personal package?
 
-> ## Challange: Last packaging steps (for now; an incomplete list)
+> ## Challenge: Last packaging steps (for now; an incomplete list)
 >
 > > ## Solutions
 > > 

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -104,9 +104,10 @@ same as the those for function documentation.
 > 1. How could the documentation file look in the end?
 >
 > > ## Solutions
+> > 
 > > 1. `R/inflammation.R`
 > > 1. `patient_ID`, `day` & `inflammatory_response`
-> > 1. See below:
+> > 1. Like this:
 > > ~~~
 > > #' Inflammation In Patients During Study...
 > > #'
@@ -129,6 +130,7 @@ the documentation file, what is left to do in our little personal package?
 > ## Challange: Last packaging steps (for now; an incomplete list)
 >
 > > ## Solutions
+> > 
 > > 1. Run `roxygen2::roxygenise()`.
 > > 1. Run RStudio's `Build > Check`. Do any errors remain?
 > > 1. After `Build > Install and Restart`, start writing your paper as a vignette.

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -127,8 +127,12 @@ same as the those for function documentation.
 > > #' }
 > > "inflammation"
 > > ~~~
+> > Note that this is exactly the ["LaTeX-like" syntax mentioned in the "Writing Documentation" section](https://tibhannover.github.io/FAIR-R/03-func-R/#technical-details-of-rs-help-page-format).
+> > With `usethis::use_roxygen_md()`, we can reduce most of those `\commands` to the [simpler Markdown format][MD].
 > {: .solution}
 {: .challenge}
+
+[MD]: https://rmarkdown.rstudio.com/authoring_basics.html
 
 After saving the raw data, the data creation script, the tidy dataset,and
 the documentation file, what is left to do in our little personal package?

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -9,8 +9,10 @@ questions:
 - "How can we add datasets to R packages?"
 objectives:
 - "Use `tidyr::gather()` to convert wide data to its long form."
+- "Find self-descriptive variable/column names."
 keypoints:
 - "Spreadsheets incentivise the wide data format, which may spread variables across columns."
+- "If variables in different dataset are comparable methodologically, their variable/column names should be spelled exactly alike."
 source: Rmd
 ---
 

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -93,4 +93,43 @@ for others and your future self, datasets benefit from a documentation as well.
 Please read through [r-pkgs.had.co.nz/data.html#documenting-data](http://r-pkgs.had.co.nz/data.html#documenting-data)
 and keep in mind, that the descriptive tags for datasets are not entirely the
 same as the those for function documentation.
-```
+
+> ## Challange: Document the dataset!
+>
+> 1. Which file should we create to document our dataset?
+> 1. Which items of our dataset should be documented?
+> 1. How could the documentation file look in the end?
+>
+> > ## Solutions
+> > 1. `R/inflammation_scores.R`
+> > 1. `patient_ID`, `day` & `inflammation_score`
+> > 1. See below:
+> > 
+> > #' Inflammation Scores Of Patients During Study...
+> > #'
+> > #' @source Inflammation scores in patients that... This study was pre-registered at
+> > #'   \url{http://wwww.alltrials.net/study...}.
+> > #' @format A data frame with the variables/columns:
+> > #' \describe{
+> > #'  \item{patient_ID}{A factor prepresenting the different patients}
+> > #'  \item{day}{Day of the inflammation measurement}
+> > #'  \item{inflammation_score}{Measured as described in the methods section of ...}
+> > #' }
+> > #' "inflammation_scores"
+> {: .solution}
+{: .challenge}
+
+After saving the raw data, the data creation script, the tidy dataset,and
+the documentation file, what is left to do in our little personal package?
+
+> ## Challange: Last packaging steps (for now; an incomplete list)
+>
+> > ## Solutions
+> > 1. Run `roxygen2::roxygenise()`.
+> > 1. Run RStudio's `Build > Check`. Do any errors remain?
+> > 1. After `Build > Install and Restart`, start writing your paper as a vignette.
+> > 1. Commit the accumulated changes. Which commits would you suggest?
+> > 
+> {: .solution}
+{: .challenge}
+

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -48,7 +48,7 @@ meaning that we:
 1. "pin" `patient_ID` as the ID variable, 
 1. define `day` as the common ID of all the `V1`, `V2`, etc. variables, and 
 1. define a name for the newly created column, in which the values from the
-   messy variables will be  be gathered.
+   messy variables will be gathered.
 
 Because the days shouldn't remain labelled with `V`s, we also convert them to
 numbers. Since `melt()` turned the variable names into factor levels of `day`,

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -107,13 +107,13 @@ same as the those for function documentation.
 > > 
 > > #' Inflammation In Patients During Study...
 > > #'
-> > #' @source Inflammation scores in patients that... This study was pre-registered at
-> > #'   \url{http://wwww.alltrials.net/study...}.
+> > #' @source Pre-registration: \url{http://wwww.alltrials.net/study...}.
+> > #'   Method: \url{...}.
 > > #' @format A data frame with the variables/columns:
 > > #' \describe{
 > > #'  \item{patient_ID}{A factor prepresenting the different patients}
-> > #'  \item{day}{Day of the inflammation measurement}
-> > #'  \item{inflammatory_response}{Measured as described in the methods section of ...}
+> > #'  \item{day}{Number of days after start of the study}
+> > #'  \item{inflammatory_response}{Measured daily as described in the methods section of ...}
 > > #' }
 > > #' "inflammation"
 > {: .solution}

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -104,7 +104,7 @@ same as the those for function documentation.
 > > 1. `R/inflammation.R`
 > > 1. `patient_ID`, `day` & `inflammatory_response`
 > > 1. See below:
-> > 
+> > ~~~
 > > #' Inflammation In Patients During Study...
 > > #'
 > > #' @source Pre-registration: \url{http://wwww.alltrials.net/study...}.
@@ -115,7 +115,8 @@ same as the those for function documentation.
 > > #'  \item{day}{Number of days after start of the study}
 > > #'  \item{inflammatory_response}{Measured daily as described in the methods section of ...}
 > > #' }
-> > #' "inflammation"
+> > "inflammation"
+> > ~~~
 > {: .solution}
 {: .challenge}
 

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -40,9 +40,10 @@ head(rownames(dat), 10)
 
 You probably noticed that neither "patients" nor "days" is listed anywhere. Thus,
 we should label the data first, starting with pseudonyms for the patients. If
-this were real data from real human patients, we would have acquired the written
-and informed consent to the pseudonymous data publication right in the beginning
-of the study, during approval by the ethics committee of our study.
+this were real data from real human patients, we would have acquired their written
+and informed consent to the pseudonymous data publication before collecting it,
+and during approval of our study by the ethics committee. We would also have 
+pre-registered our study, e.g. on [AllTrials.net](http://www.alltrials.net/).
 
 ```{r inflammation-label}
 patient_ID <- paste("patient", sep = "_", seq(60))

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -87,4 +87,11 @@ can finally package it up in an R-supported format. Rename the dataframe to some
 thing more self-descriptive than `dat...`, using for example
 `inflammation_scores <- dat_long` and then run `use_data(inflammation_scores)`.
 
+## Documenting datasets
+
+Just as a good function documentation makes your code more accessible and reusable
+for others and your future self, datasets benefit from a documentation as well.
+Please read through [r-pkgs.had.co.nz/data.html#documenting-data](http://r-pkgs.had.co.nz/data.html#documenting-data)
+and keep in mind, that the descriptive tags for datasets are not entirely the
+same as the those for function documentation.
 ```

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -51,12 +51,7 @@ meaning that we:
    messy variables will be gathered, and
 1. specify which variables we want to gather into key-value pairs.  
 
-Because the days shouldn't remain labelled with `V`s, we also convert them to
-numbers. Since `melt()` turned the variable names into factor levels of `day`,
-`as.numeric()` understands that they are already in order. No `sub("V", "")` or
-other character (literally) "assinations" are necessary.
 
-dat_long$day <- as.numeric(dat_long$day)
 ```{r inflammation-gather}
 dat_long <- tidyr::gather(dat_labelled,
                          key = "day",
@@ -69,3 +64,10 @@ Notice the row numbers? Because we gathered observations into one column, and th
 observation per row, the `r nrow(dat_long)` rows now are the product of the
 initial `r nrow(dat)` rows and `r ncol(dat)` columns.
 
+Because the days shouldn't remain labelled with `V`s, we also convert them to
+numbers. This works with either `as.factor()` and `as.numeric()` after another,
+or nested, or via `sub(pattern = "V", replacement = "")`. 
+
+```{r inflammation-days}
+dat_long$day <- as.numeric(as.factor(dat_long$day))
+```

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -33,9 +33,9 @@ of the following code examples. Think about which of them are purely for interac
 checks of the tidying process. You needn't save those to "data creation scripts".
 
 ```{r inflammation-wide}
-colnames(dat)
-rownames(dat)
 dat <- read.csv(file = "inflammation-01.csv", header = FALSE)
+head(colnames(dat), 10)
+head(rownames(dat), 10)
 ```
 
 You probably noticed that neither "patients" nor "days" is listed anywhere. Thus,

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -3,14 +3,14 @@ title: "Tidying & packaging datasets"
 teaching: 30
 exercises: 10
 questions:
-- "Which different forms can one dataset have?"
-- "Which advantages and disadvantages do these forms have?"
+- "What are possible forms that a dataset can have?"
+- "What advantages and disadvantages do these forms have?"
 - "Which features make a dataset more or less reusable?"
 - "How can we add datasets to R packages?"
 objectives:
 - "Use `tidyr::gather()` to convert wide data to its long form."
 keypoints:
-- "Excel & co. incentivise the wide data format, which may spread variables across columns."
+- "Spreadsheets incentivise the wide data format, which may spread variables across columns."
 source: Rmd
 ---
 
@@ -27,7 +27,8 @@ we need to tidy it up for further analysis and publication.
 
 ```{r inflammation-wide}
 dat <- read.csv(file = "data/inflammation-01.csv", header = FALSE)
-colnames(dat); rownames(dat)
+colnames(dat)
+rownames(dat)
 ```
 
 You probably noticed that neither "patients" nor "days" is listed anywhere. Thus,

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -30,7 +30,7 @@ First, run `library(usethis)` and `use_data_raw()` and note the `Next:` instruct
 in the console. In particular, copy the `inflammation-*.csv` files to `data-raw`
 and start a `tidy-inflammation.R` file there to which you add the necessary lines
 of the following code examples. Think about which of them are purely for interactive
-checks of the tidying process. You needn't save those to "data creation scripts".
+checks of the tidying process! Don't save those to the "data creation script".
 
 ```{r inflammation-wide}
 dat <- read.csv(file = "inflammation-01.csv", header = FALSE)

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -46,7 +46,7 @@ and during approval of our study by the ethics committee. We would also have
 pre-registered our study, e.g. on [AllTrials.net](http://www.alltrials.net/).
 
 ```{r inflammation-label}
-patient_ID <- paste("patient", sep = "_", seq(60))
+patient_ID <- paste("patient", sep = "_", seq(nrow(dat)))
 dat_labelled <- cbind(dat, patient_ID)
 head(dat_labelled)
 ```

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -13,6 +13,7 @@ objectives:
 keypoints:
 - "Spreadsheets incentivise the wide data format, which may spread variables across columns."
 - "If variables in different dataset are comparable methodologically, their variable/column names should be spelled exactly alike."
+- "(Raw) Data can be packaged by itself (and/or alongside related cleaning and analysis code)."
 source: Rmd
 ---
 

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -89,6 +89,12 @@ can finally package it up in an R-supported format. Rename the dataframe to some
 thing more self-descriptive than `dat...`, using for example
 `inflammation <- dat_long` and then run `use_data(inflammation)`.
 
+> ## In case you need to "widen" a long/tidy dataset again:
+> Use the opposite of `gather()`: [`spread()`](https://tidyr.tidyverse.org/reference/spread.html).
+> You can learn more about both in the [Data Carpentry's "Data Manipulation" lesson](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html#spreading)
+> or the ["R for Data Science" book](http://r4ds.had.co.nz/tidy-data.html#spreading).
+{: .callout}
+
 ## Documenting datasets
 
 Just as a good function documentation makes your code more accessible and reusable

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -79,4 +79,12 @@ or nested:
 
 ```{r inflammation-days}
 dat_long$day <- as.numeric(as.factor(dat_long$day))
+str(dat_long)
+```
+
+The structure of our inflammation dataset is now a lot tidier than before and we
+can finally package it up in an R-supported format. Rename the dataframe to some-
+thing more self-descriptive than `dat...`, using for example
+`inflammation_scores <- dat_long` and then run `use_data(inflammation_scores)`.
+
 ```

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -67,7 +67,7 @@ initial `r nrow(dat)` rows and `r ncol(dat)` columns.
 
 Because the days shouldn't remain labelled with `V`s, we also convert them to
 numbers. This works with either `as.factor()` and `as.numeric()` after another,
-or nested, or via `sub(pattern = "V", replacement = "")`. 
+or nested: 
 
 ```{r inflammation-days}
 dat_long$day <- as.numeric(as.factor(dat_long$day))

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -58,8 +58,7 @@ meaning that we:
 1. define `day` as the common `key` of all the `V1`, `V2`, etc. variables, 
 1. define a name for the newly created column, in which the `value`s from the
    messy variables will be gathered, and
-1. specify which variables we want to gather into key-value pairs.  
-
+1. specify which variables we want to gather into key-value pairs.
 
 ```{r inflammation-gather}
 dat_long <- tidyr::gather(dat_labelled,

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -1,0 +1,70 @@
+---
+title: "Tidying & packaging datasets"
+teaching: 30
+exercises: 10
+questions:
+- "Which different forms can one dataset have?"
+- "Which advantages and disadvantages do these forms have?"
+- "Which features make a dataset more or less reusable?"
+- "How can we add datasets to R packages?"
+objectives:
+keypoints:
+- "Excel & co. incentivise the wide data format, which may spread variables across columns."
+source: Rmd
+---
+
+```{r, include = FALSE}
+source("../bin/chunk-options.R")
+knitr_fig_path("06-tidy-data-R-")
+```
+
+## Tidying our inflammation datasets
+
+In the preparations episode, we read in, visualised, centered and rescaled a
+dataset about inflammation in 60 patients measured over 40 days. Let's pretend
+we need to tidy it up for further analysis and publication.
+
+```{r inflammation-wide}
+dat <- read.csv(file = "data/inflammation-01.csv", header = FALSE)
+colnames(dat); rownames(dat)
+```
+
+You probably noticed that neither "patients" nor "days" is listed anywhere. Thus,
+we should label the data first, starting with pseudonyms for the patients. If
+this were real data from real human patients, we would have acquired the written
+and informed consent to the pseudonymous data publication right in the beginning
+of the study, during approval by the ethics committee of our study.
+
+```{r inflammation-label}
+patient_ID <- paste("patient", sep = "_", seq(60))
+dat_labelled <- cbind(dat, patient_ID)
+head(dat_labelled)
+```
+
+Now we have labelled our observations with `patient_ID` as the column/variable
+name and `patient_…` as the values. Next we are going to "melt" the dataframe,
+meaning that we:
+
+1. "pin" `patient_ID` as the ID variable, 
+1. define `day` as the common ID of all the `V1`, `V2`, etc. variables, and 
+1. define a name for the newly created column, in which the values from the
+   messy variables will be  be gathered.
+
+Because the days shouldn't remain labelled with `V`s, we also convert them to
+numbers. Since `melt()` turned the variable names into factor levels of `day`,
+`as.numeric()` understands that they are already in order. No `sub("V", "")` or
+other character (literally) "assinations" are necessary.
+
+```{r inflammation-melt}
+dat_long <- reshape2::melt(data = dat_labelled,
+                           id.vars = "patient_ID",
+                           variable.name = "day",
+                           value.name = "inflmmation_score")
+dat_long$day <- as.numeric(dat_long$day)
+tail(dat_long)
+```
+
+Notice the row numbers? Because we "lengthened" the dataset to a single
+observation per row, the `r nrow(dat_long)` rows now are the product of the
+initial `r nrow(dat)` rows and `r ncol(dat)` columns.
+

--- a/_episodes_rmd/06-tidy-data.Rmd
+++ b/_episodes_rmd/06-tidy-data.Rmd
@@ -8,6 +8,7 @@ questions:
 - "Which features make a dataset more or less reusable?"
 - "How can we add datasets to R packages?"
 objectives:
+- "Use `tidyr::gather()` to convert wide data to its long form."
 keypoints:
 - "Excel & co. incentivise the wide data format, which may spread variables across columns."
 source: Rmd
@@ -42,29 +43,29 @@ head(dat_labelled)
 ```
 
 Now we have labelled our observations with `patient_ID` as the column/variable
-name and `patient_…` as the values. Next we are going to "melt" the dataframe,
+name and `patient_…` as the values. Next we are going to "gather" the observations,
 meaning that we:
 
-1. "pin" `patient_ID` as the ID variable, 
-1. define `day` as the common ID of all the `V1`, `V2`, etc. variables, and 
-1. define a name for the newly created column, in which the values from the
-   messy variables will be gathered.
+1. define `day` as the common `key` of all the `V1`, `V2`, etc. variables, 
+1. define a name for the newly created column, in which the `value`s from the
+   messy variables will be gathered, and
+1. specify which variables we want to gather into key-value pairs.  
 
 Because the days shouldn't remain labelled with `V`s, we also convert them to
 numbers. Since `melt()` turned the variable names into factor levels of `day`,
 `as.numeric()` understands that they are already in order. No `sub("V", "")` or
 other character (literally) "assinations" are necessary.
 
-```{r inflammation-melt}
-dat_long <- reshape2::melt(data = dat_labelled,
-                           id.vars = "patient_ID",
-                           variable.name = "day",
-                           value.name = "inflmmation_score")
 dat_long$day <- as.numeric(dat_long$day)
+```{r inflammation-gather}
+dat_long <- tidyr::gather(dat_labelled,
+                         key = "day",
+                         value = "inflammation_score",
+                         V1:V40)
 tail(dat_long)
 ```
 
-Notice the row numbers? Because we "lengthened" the dataset to a single
+Notice the row numbers? Because we gathered observations into one column, and thus one
 observation per row, the `r nrow(dat_long)` rows now are the product of the
 initial `r nrow(dat)` rows and `r ncol(dat)` columns.
 


### PR DESCRIPTION
See #3. I feel between a rock and a hard place here, about which way to go for the [12. > afternoon "Community-standard data formats, tidy data, data packages"](https://tibhannover.github.io/2018-07-09-FAIR-Data-and-Software/#schedule):

1. [R-eco…dplyr](http://www.datacarpentry.org/R-ecology-lesson/03-dplyr.html) or [r-social…tidyr](http://www.datacarpentry.org/r-socialsci/03-dplyr-tidyr/) are mature & highlight the important aspects :-)

1. The [PANGAEA remix](https://github.com/TIBHannover/2018-07-09-FAIR-Data-and-Software/blob/FAIR-dataset-remix/_episodes_rmd/FAIR-remix-PANGAEA.Rmd) is close to our hearts, but touches only a few aspects. Community-standard variable names are already aligned, so only a few lines of `gather()` & `use_data()` could be appended there.

1. The inflammation dataset can easily be tidied on the technical level, but how does one find community-standard variable names? `patient_ID` & `inflammation_score` seem logical, but are they in any ontology?

#### Ideas for this episode

- [x] convert `reshape2::melt` to `tidyr::gather()`
- [x] include raw data as files & result data as `.rda`
- ~~include all 12 files, but then how to label patients consecutively (1-60, 61-120, etc.)?~~
