### PR TITLE
Decouple example values from description

### DIFF
--- a/_episodes_rmd/03-func-R.Rmd
+++ b/_episodes_rmd/03-func-R.Rmd
@@ -198,8 +198,8 @@ center <- function(data, desired) {
 ```
 
 We could test this on our actual data, but since we don't know what the values ought to be, it will be hard to tell if the result was correct.
-Instead, let's create a vector of 0s and then center that around 3.
-This will make it simple to see if our function is working as expected:
+Instead, let's create a small vector of integers and center it around a small integer,
+so that we can comprehend, retrace and therefore check the calculation in our head:
 
 ```{r, }
 (z <- c(1, 2, 3))


### PR DESCRIPTION
- [x] ~~move the interactive testing block to right before `testthat`?~~
  - not for now, as it serves as the bridge to the data analysis
  - it could be decoupled from the documentation part, which could be moved to the packaging
- [x] @katrinleinweber: merge locally & amend `make site` results